### PR TITLE
bugfix hello-world cluttering

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -70,7 +70,7 @@ test_curl_available() {
 }
 
 test_docker_available() {
-  if ! docker run hello-world > /dev/null 2>&1
+  if ! docker info > /dev/null 2>&1
   then
      echo "Docker doesn't seem to be suitably configured for Lokl"
      exit 1


### PR DESCRIPTION
This is a bugfix for [Lokl - Docker hello-world cleanup - #16](https://github.com/leonstafford/lokl/issues/16)
Using [docker info](https://stackoverflow.com/questions/43721513/how-to-check-if-the-docker-engine-and-a-docker-container-are-running/55586977#55586977) to check if Docker is running.